### PR TITLE
Fixed params reallocation bug.

### DIFF
--- a/include/pgpp/params.h
+++ b/include/pgpp/params.h
@@ -14,6 +14,9 @@ namespace pg
 class params
 {
 public:
+    params() {_temps.reserve(50);}//prevent reallocation
+    //TODO: redesign
+
     params& add(std::string &&param);
     params& add(const std::string &param);
     params& add(const char *param, int size = -1);


### PR DESCRIPTION
_temps.push_back() may lead to internal data reallocation which will invalidate entire _param_pointers